### PR TITLE
Checkbox / Radio fix within form wizard

### DIFF
--- a/src/wizard.js
+++ b/src/wizard.js
@@ -48,7 +48,10 @@ class wizard {
         that.goTo(index);
       }
 
-      e.preventDefault();
+      if (e.target.type !== "checkbox" && (e.target.type !== "radio")) {
+          e.preventDefault();
+      }
+      
       e.stopPropagation();
     });
 


### PR DESCRIPTION
Stop e.preventDefault() from interfering with standard behavior of checkbox and radio buttons.